### PR TITLE
Added scribe context

### DIFF
--- a/care_scribe/models/scribe.py
+++ b/care_scribe/models/scribe.py
@@ -12,7 +12,7 @@ form_data_schema = {
         "properties": {
             "friendlyName": {"type": "string"},
             "id": {"type": "string"},
-            "default": {"type": "string"},
+            "current": {"type": ["number","string","boolean","object","array", "null"]},
             "description": {"type": "string"},
             "type": {"type": "string"},
             "example": {"type": "string"},
@@ -33,7 +33,7 @@ form_data_schema = {
                 },
             },
         },
-        "required": ["friendlyName", "id", "description", "type", "example", "default"],
+        "required": ["friendlyName", "id", "description", "type", "example", "current"],
     },
 }
 

--- a/care_scribe/tasks/scribe.py
+++ b/care_scribe/tasks/scribe.py
@@ -34,10 +34,7 @@ def get_openai_client():
 
 prompt_1 = """
 Given a raw transcript, your task is to extract relevant information and structure it according to a predefined schema.
-Make sure to only append to or modify the "current" data. Example - if it is asked to add a record Y in W field, where W already contains X, your response should be [X,Y].
-If it is asked to remove record Y from W field, where W already contains X and Y, your response should be [X]. NOTE : ONLY REMOVE A RECORD IF EXPLICITLY ASKED TO
-If it is asked to update record Y from W field, where W already contains X and Y, your response should be [X, Updated_Y]. Only update if explicitly asked to update or edit.
-If a record exists and was neither asked to be updated, removed or added, KEEP IT AS IS.
+Make sure to produce the response keeping the "current" data in mind. In some cases the response might be a modification of the "current" data. Example - if it is asked to add a record Y in W field, where W already contains X, your response should be [X,Y].
 Output the structured data in JSON format.
 If a field cannot be filled due to missing information in the transcript, do not include it in the output, skip that JSON key.
 For fields that offer options, output the chosen option's ID. Ensure the output strictly adheres to the JSON schema provided.

--- a/care_scribe/tasks/scribe.py
+++ b/care_scribe/tasks/scribe.py
@@ -34,7 +34,7 @@ def get_openai_client():
 
 prompt_1 = """
 Given a raw transcript, your task is to extract relevant information and structure it according to a predefined schema.
-Make sure to produce the response keeping the "current" data in mind. In some cases the response might be a modification of the "current" data. Example - if it is asked to add a record Y in W field, where W already contains X, your response should be [X,Y].
+Make sure to produce the response keeping the "current" data in mind.
 Output the structured data in JSON format.
 If a field cannot be filled due to missing information in the transcript, do not include it in the output, skip that JSON key.
 For fields that offer options, output the chosen option's ID. Ensure the output strictly adheres to the JSON schema provided.

--- a/care_scribe/tasks/scribe.py
+++ b/care_scribe/tasks/scribe.py
@@ -34,6 +34,10 @@ def get_openai_client():
 
 prompt_1 = """
 Given a raw transcript, your task is to extract relevant information and structure it according to a predefined schema.
+Make sure to only append to or modify the "current" data. Example - if it is asked to add a record Y in W field, where W already contains X, your response should be [X,Y].
+If it is asked to remove record Y from W field, where W already contains X and Y, your response should be [X]. NOTE : ONLY REMOVE A RECORD IF EXPLICITLY ASKED TO
+If it is asked to update record Y from W field, where W already contains X and Y, your response should be [X, Updated_Y]. Only update if explicitly asked to update or edit.
+If a record exists and was neither asked to be updated, removed or added, KEEP IT AS IS.
 Output the structured data in JSON format.
 If a field cannot be filled due to missing information in the transcript, do not include it in the output, skip that JSON key.
 For fields that offer options, output the chosen option's ID. Ensure the output strictly adheres to the JSON schema provided.
@@ -100,6 +104,10 @@ def process_ai_form_fill(external_id):
             logger.info(f"Generating AI response for AI form fill {form.external_id}")
             form.status = Scribe.Status.GENERATING_AI_RESPONSE
             form.save()
+            
+            print("=====")
+            print(form.form_data)
+            print("=====")
 
             # Process the transcript with Ayushma
             ai_response = get_openai_client().chat.completions.create(

--- a/care_scribe/tasks/scribe.py
+++ b/care_scribe/tasks/scribe.py
@@ -104,10 +104,6 @@ def process_ai_form_fill(external_id):
             logger.info(f"Generating AI response for AI form fill {form.external_id}")
             form.status = Scribe.Status.GENERATING_AI_RESPONSE
             form.save()
-            
-            print("=====")
-            print(form.form_data)
-            print("=====")
 
             # Process the transcript with Ayushma
             ai_response = get_openai_client().chat.completions.create(


### PR DESCRIPTION
Scribe now supports a `current` field that would contain the existing data in the field. This replaces `default`. This will let it respond in accordance to existing data.

NOTE : There are more chances for Scribe to miss out on context on GPT-4O-mini. GPT-4O is optimal.